### PR TITLE
Naver Webtoon의 신작, 매일+ 웹툰 JSON화

### DIFF
--- a/assets/data/daily_plus_webtoon.json
+++ b/assets/data/daily_plus_webtoon.json
@@ -1,0 +1,107 @@
+[
+    { 
+        "id" : "800598",
+        "title" : "시크릿 플레이어",
+        "author" : "물빛/나지하지/산지직송",
+        "rating" : "9.74",
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/800…l_IMAG06_13ffc393-94d6-4249-8d8a-111c2247c8f7.jpg"
+    },
+    { 
+        "id" : "802985" ,
+        "title" : "에이전트",
+        "author" : "준돌",
+        "rating" : "9.57",
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/802…l_IMAG06_b2ef35ed-fd75-4da1-ab28-237293c85234.jpg"
+    },
+    { 
+        "id" :  "797222",
+        "title" : "초월자 학원의 수강생이 되었다",
+        "author" : "어쩌다 / 뀨잔느 / 두파치타파",
+        "rating" : "9.82",
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/797…l_IMAG06_097096c9-0c0d-4e45-a9a0-f7e2e036a996.jpg"
+    },
+    { 
+        "id" :  "804163",
+        "title" : "호랑이 새끼",
+        "author" : "552/악새/우유양",
+        "rating" : "9.90",
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804…l_IMAG06_817bdbe7-005c-4cd2-afec-85704d868a23.jpg"
+    },
+    { 
+        "id" : "797153",
+        "title" : "일진담당일진",
+        "author" : "GRIMZO",
+        "rating" : "9.85",
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/797…l_IMAG06_ffb49bfb-e380-4ca0-9438-b0f227630bbb.jpg"
+    },
+    { 
+        "id" :  "794099",
+        "title" : "북경신보",
+        "author" : "산하/김대영",
+        "rating" : "9.92",
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/794…l_IMAG06_78d133bd-3bd5-45ce-81fa-2659ba3716ea.jpg"
+    },
+    { 
+        "id" : "792949",
+        "title" : "괴이",
+        "author" : "이정우/홍인근",
+        "rating" : "9.81",
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/792…l_IMAG06_70faed92-6997-400f-83cb-3735fe2097a8.jpg"
+    },
+    { 
+        "id" : "729938",
+        "title" : "금혼령-조선혼인금지령",
+        "author" : "천지혜 / 산책",
+        "rating" : "9.96",
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/729…l_IMAG06_3f79afb3-2156-4a36-8506-7788e308c8cb.jpg"
+    },
+    { 
+        "id" : "803208",
+        "title" : "본능적인 그대",
+        "author" : "정해진 / 갱아 / 이달아",
+        "rating" : "9.91",
+        "thumb" : "-"
+    },
+    { 
+        "id" : "787495",
+        "title" : "꿈에서 자유로",
+        "author" : "2L",
+        "rating" : "9.96",
+        "thumb" : "-"
+    },
+    { 
+        "id" : "803458",
+        "title" : "비스트번",
+        "author" : "윤선생",
+        "rating" : "9.77",
+        "thumb" : "-"
+    },
+    { 
+        "id" : "784813",
+        "title" : "퇴마록",
+        "author" : "운 / 이협 / 이우혁",
+        "rating" :"9.93",
+        "thumb" : "-"
+    },
+    { 
+        "id" : "801476",
+        "title" : "신 고구려전기",
+        "author" : "장작가 / 닼슼 / 풍아저씨",
+        "rating" : "9.94",
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/801…l_IMAG06_4accd6b4-b2e6-40ac-890c-27c25682ccf9.jpg"
+    },
+    { 
+        "id" : "787669",
+        "title" : "뉴심:교체인생",
+        "author" : "지인",
+        "rating" : "9.92",
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/787…l_IMAG06_a7aef044-d14c-494e-8a3d-3137ee992c33.jpg"
+    },
+    { 
+        "id" : "801105",
+        "title" : "저주가 저주가 아닌 게 저주",
+        "author" : "가향 / 제과제뼈",
+        "rating" : "9.84",
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/801…l_IMAG06_6929805a-2e20-4c6e-9e60-39c281dbd747.jpg"
+    }
+]

--- a/assets/data/new_webtoon.json
+++ b/assets/data/new_webtoon.json
@@ -1,0 +1,65 @@
+[
+    { 
+        "id" :  804989,
+        "title" : "굿헌팅",
+        "author" : "HB / 홍반장,심조",
+        "rating" : 9.85,
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804989/thumbnail/thumbnail_IMAG06_b106b95f-6b29-4301-80db-1c051e42255f.jpg"
+    },
+    { 
+        "id" : 804871,
+        "title" : "넷시의 비밀",
+        "author" : "비온후",
+        "rating" : 9.86,
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804871/thumbnail/thumbnail_IMAG06_92f89475-cf04-4821-86ad-c91ad9bc34a8.jpg"
+    },
+    { 
+        "id" : 803891,
+        "title" : "용한소녀",
+        "author" : "올소",
+        "rating" : 9.97,
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/803891/thumbnail/thumbnail_IMAG06_47084634-ea6a-4eb4-b98a-01d0b30dcb28.jpg"
+    },
+    { 
+        "id" : 804333,
+        "title" : "그냥 선생님",
+        "author" : "연일",
+        "rating" : 9.97,
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804333/thumbnail/thumbnail_IMAG06_d5dd2456-5b72-482c-adef-b3344b8cb7f7.jpg"
+    },
+    { 
+        "id" : 804783,
+        "title" : "사변괴담",
+        "author" : "강태진",
+        "rating" : 9.60,
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804783/thumbnail/thumbnail_IMAG06_d58680f1-5310-48f0-9e73-f3aaa001cdce.jpg"
+    },
+    { 
+        "id" : 804653,
+        "title" : "유사연애",
+        "author" : "여은",
+        "rating" : 9.89,
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804653/thumbnail/thumbnail_IMAG06_1d440141-34c3-4c95-a7f4-4e28d9e411fd.jpg"
+    },
+    { 
+        "id" : 804469,
+        "title" : "원하나",
+        "author" : "비진",
+        "rating" : 9.86,
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804469/thumbnail/thumbnail_IMAG06_f98a6600-7225-4df2-9fb2-93f487e66da1.jpg"
+    },
+    { 
+        "id" : 805156,
+        "title" : "고양이 타타",
+        "author" : "로로",
+        "rating" : 9.97,
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/805156/thumbnail/thumbnail_IMAG06_f9e2670d-0db6-477b-a1f7-be44dc14b264.jpg"
+    },
+    { 
+        "id" : 804329,
+        "title" : "약탈 신부",
+        "author" : "팀 카푸치노",
+        "rating" : 9.95,
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804329/thumbnail/thumbnail_IMAG06_f4e0f1cb-f4ec-4ee0-9b60-ffd37788d075.jpg"
+    }
+]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,9 +63,9 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
+  assets:
+  - assets/data/daily_plus_webtoon.json
+  - assets/data/new_webtoon.json
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware


### PR DESCRIPTION
# 한 것
네이버 API는 공개가 아니기 때문에 
네이버 웹툰의 신작, 매일+ 웹툰의 정보를 JSON 파일로 만듦.

pubspec.yml 파일에 asset 추가
- json 파일을 사용해야하기 때문에 등록시킴.
