### PR TITLE
Feature/webtoon list - 웹툰 목록

### DIFF
--- a/assets/data/daily_plus_webtoon.json
+++ b/assets/data/daily_plus_webtoon.json
@@ -4,104 +4,104 @@
         "title" : "시크릿 플레이어",
         "author" : "물빛/나지하지/산지직송",
         "rating" : "9.74",
-        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/800…l_IMAG06_13ffc393-94d6-4249-8d8a-111c2247c8f7.jpg"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/800598/thumbnail/thumbnail_IMAG06_13ffc393-94d6-4249-8d8a-111c2247c8f7.jpg"
     },
-    { 
+    {
         "id" : "802985" ,
         "title" : "에이전트",
         "author" : "준돌",
         "rating" : "9.57",
-        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/802…l_IMAG06_b2ef35ed-fd75-4da1-ab28-237293c85234.jpg"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/802985/thumbnail/thumbnail_IMAG06_b2ef35ed-fd75-4da1-ab28-237293c85234.jpg"
     },
     { 
         "id" :  "797222",
         "title" : "초월자 학원의 수강생이 되었다",
         "author" : "어쩌다 / 뀨잔느 / 두파치타파",
         "rating" : "9.82",
-        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/797…l_IMAG06_097096c9-0c0d-4e45-a9a0-f7e2e036a996.jpg"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/797222/thumbnail/thumbnail_IMAG06_097096c9-0c0d-4e45-a9a0-f7e2e036a996.jpg"
     },
     { 
         "id" :  "804163",
         "title" : "호랑이 새끼",
         "author" : "552/악새/우유양",
         "rating" : "9.90",
-        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804…l_IMAG06_817bdbe7-005c-4cd2-afec-85704d868a23.jpg"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804163/thumbnail/thumbnail_IMAG06_817bdbe7-005c-4cd2-afec-85704d868a23.jpg"
     },
     { 
         "id" : "797153",
         "title" : "일진담당일진",
         "author" : "GRIMZO",
         "rating" : "9.85",
-        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/797…l_IMAG06_ffb49bfb-e380-4ca0-9438-b0f227630bbb.jpg"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/797153/thumbnail/thumbnail_IMAG06_ffb49bfb-e380-4ca0-9438-b0f227630bbb.jpg"
     },
     { 
         "id" :  "794099",
         "title" : "북경신보",
         "author" : "산하/김대영",
         "rating" : "9.92",
-        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/794…l_IMAG06_78d133bd-3bd5-45ce-81fa-2659ba3716ea.jpg"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/794099/thumbnail/thumbnail_IMAG06_78d133bd-3bd5-45ce-81fa-2659ba3716ea.jpg"
     },
     { 
         "id" : "792949",
         "title" : "괴이",
         "author" : "이정우/홍인근",
         "rating" : "9.81",
-        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/792…l_IMAG06_70faed92-6997-400f-83cb-3735fe2097a8.jpg"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/792949/thumbnail/thumbnail_IMAG06_70faed92-6997-400f-83cb-3735fe2097a8.jpg"
     },
     { 
         "id" : "729938",
         "title" : "금혼령-조선혼인금지령",
         "author" : "천지혜 / 산책",
         "rating" : "9.96",
-        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/729…l_IMAG06_3f79afb3-2156-4a36-8506-7788e308c8cb.jpg"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/729938/thumbnail/thumbnail_IMAG06_3f79afb3-2156-4a36-8506-7788e308c8cb.jpg"
     },
     { 
         "id" : "803208",
         "title" : "본능적인 그대",
         "author" : "정해진 / 갱아 / 이달아",
         "rating" : "9.91",
-        "thumb" : "-"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/803208/thumbnail/thumbnail_IMAG06_ff719ad9-24e4-4b8b-a412-cdcade0a3d38.jpg"
     },
     { 
         "id" : "787495",
         "title" : "꿈에서 자유로",
         "author" : "2L",
         "rating" : "9.96",
-        "thumb" : "-"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/787495/thumbnail/thumbnail_IMAG06_8b08fcb5-73f4-4701-aba9-496cbd0e062a.jpg"
     },
     { 
         "id" : "803458",
         "title" : "비스트번",
         "author" : "윤선생",
         "rating" : "9.77",
-        "thumb" : "-"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/803458/thumbnail/thumbnail_IMAG06_0b871876-d88d-41fe-943b-7a24f7e01f44.jpg"
     },
     { 
         "id" : "784813",
         "title" : "퇴마록",
         "author" : "운 / 이협 / 이우혁",
         "rating" :"9.93",
-        "thumb" : "-"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/784813/thumbnail/thumbnail_IMAG06_7a913e68-4774-4bc6-9537-f1c07d1f0e16.jpg"
     },
     { 
         "id" : "801476",
         "title" : "신 고구려전기",
         "author" : "장작가 / 닼슼 / 풍아저씨",
         "rating" : "9.94",
-        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/801…l_IMAG06_4accd6b4-b2e6-40ac-890c-27c25682ccf9.jpg"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/801476/thumbnail/thumbnail_IMAG06_4accd6b4-b2e6-40ac-890c-27c25682ccf9.jpg"
     },
     { 
         "id" : "787669",
         "title" : "뉴심:교체인생",
         "author" : "지인",
         "rating" : "9.92",
-        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/787…l_IMAG06_a7aef044-d14c-494e-8a3d-3137ee992c33.jpg"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/787669/thumbnail/thumbnail_IMAG06_a7aef044-d14c-494e-8a3d-3137ee992c33.jpg"
     },
     { 
         "id" : "801105",
         "title" : "저주가 저주가 아닌 게 저주",
         "author" : "가향 / 제과제뼈",
         "rating" : "9.84",
-        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/801…l_IMAG06_6929805a-2e20-4c6e-9e60-39c281dbd747.jpg"
+        "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/801105/thumbnail/thumbnail_IMAG06_6929805a-2e20-4c6e-9e60-39c281dbd747.jpg"
     }
 ]

--- a/assets/data/new_webtoon.json
+++ b/assets/data/new_webtoon.json
@@ -1,65 +1,65 @@
 [
     { 
-        "id" :  804989,
+        "id" :  "804989",
         "title" : "굿헌팅",
         "author" : "HB / 홍반장,심조",
-        "rating" : 9.85,
+        "rating" : "9.85",
         "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804989/thumbnail/thumbnail_IMAG06_b106b95f-6b29-4301-80db-1c051e42255f.jpg"
     },
     { 
-        "id" : 804871,
+        "id" : "804871",
         "title" : "넷시의 비밀",
         "author" : "비온후",
-        "rating" : 9.86,
+        "rating" : "9.86",
         "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804871/thumbnail/thumbnail_IMAG06_92f89475-cf04-4821-86ad-c91ad9bc34a8.jpg"
     },
     { 
-        "id" : 803891,
+        "id" : "803891",
         "title" : "용한소녀",
         "author" : "올소",
-        "rating" : 9.97,
+        "rating" : "9.97",
         "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/803891/thumbnail/thumbnail_IMAG06_47084634-ea6a-4eb4-b98a-01d0b30dcb28.jpg"
     },
     { 
-        "id" : 804333,
+        "id" : "804333",
         "title" : "그냥 선생님",
         "author" : "연일",
-        "rating" : 9.97,
+        "rating" : "9.97",
         "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804333/thumbnail/thumbnail_IMAG06_d5dd2456-5b72-482c-adef-b3344b8cb7f7.jpg"
     },
     { 
-        "id" : 804783,
+        "id" : "804783",
         "title" : "사변괴담",
         "author" : "강태진",
-        "rating" : 9.60,
+        "rating" : "9.60",
         "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804783/thumbnail/thumbnail_IMAG06_d58680f1-5310-48f0-9e73-f3aaa001cdce.jpg"
     },
     { 
-        "id" : 804653,
+        "id" : "804653",
         "title" : "유사연애",
         "author" : "여은",
-        "rating" : 9.89,
+        "rating" : "9.89",
         "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804653/thumbnail/thumbnail_IMAG06_1d440141-34c3-4c95-a7f4-4e28d9e411fd.jpg"
     },
     { 
-        "id" : 804469,
+        "id" : "804469",
         "title" : "원하나",
         "author" : "비진",
-        "rating" : 9.86,
+        "rating" : "9.86",
         "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804469/thumbnail/thumbnail_IMAG06_f98a6600-7225-4df2-9fb2-93f487e66da1.jpg"
     },
     { 
-        "id" : 805156,
+        "id" : "805156",
         "title" : "고양이 타타",
         "author" : "로로",
-        "rating" : 9.97,
+        "rating" : "9.97",
         "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/805156/thumbnail/thumbnail_IMAG06_f9e2670d-0db6-477b-a1f7-be44dc14b264.jpg"
     },
     { 
-        "id" : 804329,
+        "id" : "804329",
         "title" : "약탈 신부",
         "author" : "팀 카푸치노",
-        "rating" : 9.95,
+        "rating" : "9.95",
         "thumb" : "https://shared-comic.pstatic.net/thumb/webtoon/804329/thumbnail/thumbnail_IMAG06_f4e0f1cb-f4ec-4ee0-9b60-ffd37788d075.jpg"
     }
 ]

--- a/lib/models/app_model.dart
+++ b/lib/models/app_model.dart
@@ -6,9 +6,9 @@ class WebToonAppModel {
   final double rating;
 
   WebToonAppModel.fromJson(Map<String, dynamic> json)
-      : id = json['id'] as int,
+      : id = int.parse(json['id']),
         title = json['title'].toString(),
         author = json['author'].toString(),
         thumb = json['thumb'].toString(),
-        rating = json['rating'] as double;
+        rating = double.parse(json['rating']);
 }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -12,8 +12,9 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
-  // final Future<List<WebToonModel>> webtoons = ApiService.getTodaysWebToons();
-  final Future<List<WebToonAppModel>> webtoons = ApiService.getNewWebtoons();
+  final Future<List<WebToonAppModel>> newWebtoon = ApiService.getNewWebtoons();
+  final Future<List<WebToonAppModel>> dailyWebtoon =
+      ApiService.getdailyWebtoons();
   late TabController _myTabs;
   double tabWidth = 0;
   final int todayWeekday = DateTime.now().weekday + 1;
@@ -26,6 +27,7 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
       vsync: this,
       initialIndex: todayWeekday,
     );
+    print(tabBarView.length);
   }
 
   @override
@@ -109,49 +111,81 @@ class _HomeScreenState extends State<HomeScreen> with TickerProviderStateMixin {
   List<Widget> get tabBarView {
     List<Widget> arr = [];
     for (var i = 0; i < 10; i++) {
-      arr.add(
-        FutureBuilder(
-          future: webtoons,
-          builder: (context, futureResult) {
-            if (futureResult.hasData) {
-              return Column(
-                children: [
-                  const SizedBox(
-                    height: 50,
-                  ),
-                  Expanded(
-                    child: makeList(futureResult),
-                  ),
-                ],
-              );
-            } else {
-              return const Center(
-                child: CircularProgressIndicator(),
-              );
-            }
-          },
-        ),
-      );
+      if (i == 0) {
+        arr.add(
+          FutureBuilder(
+            future: newWebtoon,
+            builder: (context, futureResult) {
+              if (futureResult.hasData) {
+                return Container(
+                  child: makeList(futureResult),
+                );
+              } else {
+                return const Center(
+                  child: CircularProgressIndicator(),
+                );
+              }
+            },
+          ),
+        );
+      } else if (i == 1) {
+        arr.add(
+          FutureBuilder(
+            future: dailyWebtoon,
+            builder: (context, futureResult) {
+              if (futureResult.hasData) {
+                return Container(
+                  child: makeList(futureResult),
+                );
+              } else {
+                return const Center(
+                  child: CircularProgressIndicator(),
+                );
+              }
+            },
+          ),
+        );
+      } else {
+        arr.add(
+          FutureBuilder(
+            future: dailyWebtoon,
+            builder: (context, futureResult) {
+              if (futureResult.hasData) {
+                return Container(
+                  child: makeList(futureResult),
+                );
+              } else {
+                return const Center(
+                  child: CircularProgressIndicator(),
+                );
+              }
+            },
+          ),
+        );
+      }
     }
     return arr;
   }
 
-  ListView makeList(AsyncSnapshot<List<WebToonAppModel>> futureResult) {
-    return ListView.separated(
-      scrollDirection: Axis.horizontal,
+  GridView makeList(AsyncSnapshot<List<WebToonAppModel>> futureResult) {
+    return GridView.builder(
+      // GridView가 어떻게 구성될지 Delegate(대리자)로 설정
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 3,
+        mainAxisSpacing: 2,
+        crossAxisSpacing: 2,
+        childAspectRatio: 3 / 4,
+      ),
+      scrollDirection: Axis.vertical,
       itemCount: futureResult.data!.length,
       padding: const EdgeInsets.symmetric(
-        vertical: 10,
+        vertical: 20,
         horizontal: 20,
       ),
       itemBuilder: (context, index) {
         var webtoon = futureResult.data![index];
         return AppWebToonCard(webtoon: webtoon);
       },
-      // 구분자를 build 하는 인자
-      separatorBuilder: (context, index) => const SizedBox(
-        width: 40,
-      ),
     );
   }
   // ListView makeList(AsyncSnapshot<List<WebToonModel>> futureResult) {

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -56,10 +56,11 @@ class ApiService {
   static Future<List<WebToonAppModel>> getdailyWebtoons() async {
     List<WebToonAppModel> items = [];
     final String response =
-        await rootBundle.loadString('assets/data/daily_plus_webtoon.json');
-    final data = json.decode(response);
+        await rootBundle.loadString('data/daily_plus_webtoon.json');
+    final List<dynamic> data = await jsonDecode(response);
     for (var webtoon in data) {
-      items.add(WebToonAppModel.fromJson(webtoon));
+      WebToonAppModel webtoon2 = WebToonAppModel.fromJson(webtoon);
+      items.add(webtoon2);
     }
     return items;
   }

--- a/lib/widgets/webtoon/app_webtoon_card.dart
+++ b/lib/widgets/webtoon/app_webtoon_card.dart
@@ -14,7 +14,6 @@ class AppWebToonCard extends StatelessWidget {
   Widget build(BuildContext context) {
     return GestureDetector(
       onTap: () {
-        print("온 땁!");
         // StatelessWidget을 route로 감싸서 다른 스크린처럼 보이게 해 줌.
         Navigator.push(
             context,
@@ -24,39 +23,55 @@ class AppWebToonCard extends StatelessWidget {
               // chrome은 그냥 페이지 변경하는 것 같음.
             ));
       },
-      child: Column(
-        children: [
-          // 같은 tag의 widget을 연결해 줌
-          Hero(
-            tag: webtoon.id,
-            child: Container(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(15),
-                boxShadow: [
-                  BoxShadow(
-                    blurRadius: 15,
-                    offset: const Offset(10, 7),
-                    color: Colors.black.withOpacity(0.8),
-                  )
-                ],
-              ),
-              clipBehavior: Clip.hardEdge,
-              width: 250,
-              child: Image.network(
-                webtoon.thumb,
-                fit: BoxFit.fill,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: 7,
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 같은 tag의 widget을 연결해 줌
+            Flexible(
+              flex: 7,
+              child: Hero(
+                tag: webtoon.id,
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(15),
+                  ),
+                  width: double.infinity,
+                  height: 300,
+                  clipBehavior: Clip.hardEdge,
+                  child: Image.network(
+                    webtoon.thumb,
+                    fit: BoxFit.fill,
+                  ),
+                ),
               ),
             ),
-          ),
-          const SizedBox(height: 10),
-          Text(
-            webtoon.title,
-            style: const TextStyle(
-              fontSize: 22,
-              fontWeight: FontWeight.w600,
+            const SizedBox(height: 3),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  webtoon.title,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                Text(
+                  webtoon.author,
+                  style: const TextStyle(
+                    fontSize: 10,
+                  ),
+                ),
+              ],
             ),
-          ),
-        ],
+            const SizedBox(height: 10),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
# 한 것
- JSON 파일의 웹툰의 id를 String으로 변경
- home_screen에서 매일+ 데이터 fetch
- ListView -> GridView.builder 를 이용해 목록을 Grid로 만듦
- 탭 별로 TabView 나눔
![image](https://user-images.githubusercontent.com/88869529/213420286-fbb9ea30-db1d-4526-ba21-7e8a3b87c748.png)

# 이슈 
lib/models/app_model.dart에서 dynamic으로 들어온게  as를 사용하면 제대로 값이 변화하지 않아 Error 뜸.

# 이슈 해결
as -> 자료형.parse로 변경

# 할 것

- 화면을 늘리면 column이 늘어나기 때문에 image와 간격도 늘어남.
- 일정 비율이 넘어가면 고정시키게 Mediaquery 사용 ( 추후 )
- 제목이 늘어나면 이미지 부분이 줄어 듦. 글자가 길다면 넘는 부분을 ... 표시